### PR TITLE
Fix precision problems in the half benchmarks

### DIFF
--- a/benchmark/syclblas/blas1/asum.cpp
+++ b/benchmark/syclblas/blas1/asum.cpp
@@ -48,6 +48,12 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 
   // Create data
   std::vector<data_t> v1 = blas_benchmark::utils::random_data<data_t>(size);
+
+  // We need to guarantee that cl::sycl::half can hold the sum
+  // of x_v without overflow by making sum(x_v) to be 1.0
+  std::transform(std::begin(v1), std::end(v1), std::begin(v1),
+                 [=](data_t x) { return x / v1.size(); });
+
   data_t vr;
 
   auto inx = utils::make_quantized_buffer<scalar_t>(ex, v1);

--- a/benchmark/syclblas/blas1/axpy.cpp
+++ b/benchmark/syclblas/blas1/axpy.cpp
@@ -69,7 +69,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   }
 
   std::ostringstream err_stream;
-  if (!utils::compare_vectors(y_temp, y_ref, err_stream, "")) {
+  if (!utils::compare_vectors<data_t, scalar_t>(y_temp, y_ref, err_stream,
+                                                "")) {
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;

--- a/benchmark/syclblas/blas1/iamax.cpp
+++ b/benchmark/syclblas/blas1/iamax.cpp
@@ -51,6 +51,10 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   std::vector<data_t> v1 = blas_benchmark::utils::random_data<data_t>(size);
   tuple_scalar_t out{-1, 0};
 
+  // This will clamp the values to what scalar_t can represent
+  std::transform(std::begin(v1), std::end(v1), std::begin(v1),
+                 [](data_t v) { return utils::clamp_to_limits<scalar_t>(v); });
+
   auto inx = utils::make_quantized_buffer<scalar_t>(ex, v1);
   auto outI = blas::make_sycl_iterator_buffer<tuple_scalar_t>(&out, 1);
 

--- a/benchmark/syclblas/blas1/iamin.cpp
+++ b/benchmark/syclblas/blas1/iamin.cpp
@@ -51,6 +51,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   std::vector<data_t> v1 = blas_benchmark::utils::random_data<data_t>(size);
   tuple_scalar_t out{0, 0};
 
+  std::transform(std::begin(v1), std::end(v1), std::begin(v1),
+                 [](data_t v) { return utils::clamp_to_limits<scalar_t>(v); });
+
   auto inx = utils::make_quantized_buffer<scalar_t>(ex, v1);
   auto outI = blas::make_sycl_iterator_buffer<tuple_scalar_t>(&out, 1);
 

--- a/benchmark/syclblas/blas1/nrm2.cpp
+++ b/benchmark/syclblas/blas1/nrm2.cpp
@@ -49,6 +49,10 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   // Create data
   std::vector<data_t> v1 = blas_benchmark::utils::random_data<data_t>(size);
 
+  // We need to guarantee that cl::sycl::half can hold the norm of the vector
+  std::transform(std::begin(v1), std::end(v1), std::begin(v1),
+                 [=](data_t x) { return x / v1.size(); });
+
   auto inx = utils::make_quantized_buffer<scalar_t>(ex, v1);
   auto inr = blas::make_sycl_iterator_buffer<scalar_t>(1);
 
@@ -64,7 +68,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
     ex.get_policy_handler().wait(event);
   }
 
-  if (!utils::almost_equal(vr_temp, vr_ref)) {
+  if (!utils::almost_equal<data_t, scalar_t>(vr_temp, vr_ref)) {
     std::ostringstream err_stream;
     err_stream << "Value mismatch: " << vr_temp << "; expected " << vr_ref;
     const std::string& err_str = err_stream.str();

--- a/benchmark/syclblas/blas2/gemv.cpp
+++ b/benchmark/syclblas/blas2/gemv.cpp
@@ -102,7 +102,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int ti, index_t m,
   }
 
   std::ostringstream err_stream;
-  if (!utils::compare_vectors(v_y_temp, v_y_ref, err_stream, "")) {
+  if (!utils::compare_vectors<data_t, scalar_t>(v_y_temp, v_y_ref, err_stream,
+                                                "")) {
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;

--- a/benchmark/syclblas/blas3/gemm.cpp
+++ b/benchmark/syclblas/blas3/gemm.cpp
@@ -79,7 +79,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
   }
 
   std::ostringstream err_stream;
-  if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+  if (!utils::compare_vectors<data_t, scalar_t>(c_temp, c_ref, err_stream,
+                                                "")) {
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;

--- a/benchmark/syclblas/blas3/gemm_batched.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched.cpp
@@ -172,7 +172,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
   }
 
   std::ostringstream err_stream;
-  if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+  if (!utils::compare_vectors<data_t, scalar_t>(c_temp, c_ref, err_stream,
+                                                "")) {
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;

--- a/include/utils/float_comparison.hpp
+++ b/include/utils/float_comparison.hpp
@@ -36,6 +36,16 @@ inline std::ostream& operator<<(std::ostream& os, const cl::sycl::half& value) {
   os << static_cast<float>(value);
   return os;
 }
+
+namespace std {
+template <>
+class numeric_limits<cl::sycl::half> {
+ public:
+  static constexpr float min() { return -65504.0f; }
+  static constexpr float max() { return 65504.0f; }
+};
+}  // namespace std
+
 #endif  // BLAS_DATA_TYPE_HALF
 
 namespace utils {
@@ -73,6 +83,19 @@ inline cl::sycl::half abs<cl::sycl::half>(cl::sycl::half value) noexcept {
 }
 
 #endif  // BLAS_DATA_TYPE_HALF
+
+template <typename scalar_t>
+scalar_t clamp_to_limits(scalar_t v) {
+  constexpr auto min_value = std::numeric_limits<scalar_t>::min();
+  constexpr auto max_value = std::numeric_limits<scalar_t>::max();
+  if (decltype(min_value)(v) < min_value) {
+    return min_value;
+  } else if (decltype(max_value)(v) > max_value) {
+    return max_value;
+  } else {
+    return v;
+  }
+}
 
 /**
  * Indicates the tolerated margin for relative differences

--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -19,7 +19,7 @@ void run_test(const combination_t<scalar_t> combi) {
 
   // This will remove infs from the vector
   std::transform(std::begin(x_v), std::end(x_v), std::begin(x_v),
-                 [](data_t v) { return clamp<scalar_t>(v); });
+                 [](data_t v) { return utils::clamp_to_limits<scalar_t>(v); });
 
   // Output scalar
   tuple_t out_s{0, 0.0};

--- a/test/unittest/blas1/blas1_iamin_test.cpp
+++ b/test/unittest/blas1/blas1_iamin_test.cpp
@@ -52,7 +52,7 @@ void run_test(const combination_t<scalar_t> combi) {
 
   // Removes infs from the vector
   std::transform(std::begin(x_v), std::end(x_v), std::begin(x_v),
-                 [](data_t v) { return clamp<scalar_t>(v); });
+                 [](data_t v) { return utils::clamp_to_limits<scalar_t>(v); });
 
   // Output scalar
   tuple_t out_s{0, max};

--- a/test/unittest/blas1/blas1_iaminmax_common.hpp
+++ b/test/unittest/blas1/blas1_iaminmax_common.hpp
@@ -38,28 +38,6 @@ enum class generation_mode_t : char {
 template <typename scalar_t>
 using combination_t = std::tuple<int, int, generation_mode_t>;
 
-namespace std {
-template <>
-class numeric_limits<cl::sycl::half> {
- public:
-  static constexpr float min() { return -65504.0f; }
-  static constexpr float max() { return 65504.0f; }
-};
-}  // namespace std
-
-template<typename scalar_t>
-scalar_t clamp(scalar_t v) {
-  constexpr auto min_value = std::numeric_limits<scalar_t>::min();
-  constexpr auto max_value = std::numeric_limits<scalar_t>::max();
-  if (decltype(min_value)(v) < min_value) {
-    return min_value;
-  } else if (decltype(max_value)(v) > max_value) {
-    return max_value;
-  } else {
-    return v;
-  }
-}
-
 template <typename scalar_t>
 void populate_data(generation_mode_t mode, scalar_t limit,
                    std::vector<scalar_t> &vec) {


### PR DESCRIPTION
Need to make sure the comparisons are fair depending on the data type

These changes are required to avoid precision problems in the benchmarks